### PR TITLE
Bumped GOLANG to 1.14.1

### DIFF
--- a/etc/docker/api.Dockerfile
+++ b/etc/docker/api.Dockerfile
@@ -1,5 +1,5 @@
 # should match cloud.gov manifest GOVERSION
-FROM golang:1.12
+FROM golang:1.14.1
 
 # install dep
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh

--- a/etc/manifests/api.yml
+++ b/etc/manifests/api.yml
@@ -10,5 +10,5 @@ applications:
   # defined in bin/setup-cloudgov
   - revampd-psql
   env:
-    GOVERSION: go1.12
+    GOVERSION: go1.14.1
     GOPACKAGENAME: github.com/USEPA/revampd


### PR DESCRIPTION
Cloud.gov stopped supporting GO 1.12.  I updated the application to use version 1.14.1.