### PR TITLE
Update go.yml to add OWAP ZAP Baseline Scan

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,11 +23,17 @@ jobs:
 
     - name: Build and test
       run: docker-compose run --rm api make
+      
+    - name: ZAP Scan
+      if: ${{ success() }}
+      uses: zaproxy/action-baseline@v0.3.0
+      with:
+        target: 'http://localhost:9080'
     
     - name: Make the cloudgov-deploy script executable
-      if: success() 
+      if: ${{ success() }}
       run: chmod +x ./bin/deploy-cloudgov
     
     - name: Deploy the app to cloud.gov
-      if: success()
+      if: ${{ success() }}
       run: ./bin/deploy-cloudgov


### PR DESCRIPTION
Given that the action spins up a docker container in an ubuntu virtual machine, the zap scan (which also resides in a docker container) should be able to access the app within the docker container via localhost. However, I could be wrong in that assumption. 

We could also have it point to the deployed app within cloud.gov after that step. Not sure what is best, but I want to try this and see if it can reach it via localhost within the virtual env.