### PR TITLE
OWASP ZAP Baseline Scan Action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,11 +28,10 @@ jobs:
       # frontend
       run: |
         ip addr show docker0
-        ping -i 0.2 172.17.0.1:9080
-        ping -1 0.2 172.17.0.1:8080
+        ping -W 5 172.17.0.1
+        nmap -p 9080 172.17.0.1
       
     - name: ZAP Scan
-      if: ${{ success() }}
       uses: zaproxy/action-baseline@v0.3.0
       with:
         target: 'http://172.17.0.1:9080'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Ping docker container
       # frontend
       run: |
+        ip addr show docker0
         ping -i 0.2 localhost:9080
         ping -1 0.2 localhost:8080
       

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,4 +37,4 @@ jobs:
       uses: zaproxy/action-baseline@v0.3.0
       with:
         target: 'https://revampd.app.cloud.gov'
-        cmd_options: '-I'
+        cmd_options: '-I' # Don't fail on WARNings

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,13 +24,6 @@ jobs:
     - name: Build and test
       run: docker-compose run --rm api make
       
-    - name: Ping docker container
-      # frontend
-      run: |
-        ip addr show docker0
-        ping -W 5 172.17.0.1
-        nmap -p 9080 172.17.0.1
-      
     - name: ZAP Scan
       uses: zaproxy/action-baseline@v0.3.0
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,3 +37,4 @@ jobs:
       uses: zaproxy/action-baseline@v0.3.0
       with:
         target: 'https://revampd.app.cloud.gov'
+        cmd_options: '-I'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,11 +23,6 @@ jobs:
 
     - name: Build and test
       run: docker-compose run --rm api make
-      
-    - name: ZAP Scan
-      uses: zaproxy/action-baseline@v0.3.0
-      with:
-        target: 'http://172.17.0.1'
     
     - name: Make the cloudgov-deploy script executable
       if: ${{ success() }}
@@ -36,3 +31,9 @@ jobs:
     - name: Deploy the app to cloud.gov
       if: ${{ success() }}
       run: ./bin/deploy-cloudgov
+      
+    - name: ZAP Scan
+      if: ${{ success() }}
+      uses: zaproxy/action-baseline@v0.3.0
+      with:
+        target: 'https://revampd.app.cloud.gov'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,11 +24,17 @@ jobs:
     - name: Build and test
       run: docker-compose run --rm api make
       
-    - name: ZAP Scan
-      if: ${{ success() }}
-      uses: zaproxy/action-baseline@v0.3.0
-      with:
-        target: 'http://localhost:9080'
+    - name: Ping docker container
+      # frontend
+      run: |
+        ping -i 0.2 localhost:9080
+        ping -1 0.2 localhost:8080
+      
+ #   - name: ZAP Scan
+  #    if: ${{ success() }}
+   #   uses: zaproxy/action-baseline@v0.3.0
+    #  with:
+     #   target: 'http://localhost:9080'
     
     - name: Make the cloudgov-deploy script executable
       if: ${{ success() }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,14 +28,14 @@ jobs:
       # frontend
       run: |
         ip addr show docker0
-        ping -i 0.2 localhost:9080
-        ping -1 0.2 localhost:8080
+        ping -i 0.2 172.17.0.1:9080
+        ping -1 0.2 172.17.0.1:8080
       
- #   - name: ZAP Scan
-  #    if: ${{ success() }}
-   #   uses: zaproxy/action-baseline@v0.3.0
-    #  with:
-     #   target: 'http://localhost:9080'
+    - name: ZAP Scan
+      if: ${{ success() }}
+      uses: zaproxy/action-baseline@v0.3.0
+      with:
+        target: 'http://172.17.0.1:9080'
     
     - name: Make the cloudgov-deploy script executable
       if: ${{ success() }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,11 +23,17 @@ jobs:
 
     - name: Build and test
       run: docker-compose run --rm api make
+      
+    - name: ZAP Scan
+      if: ${{ success() }}
+      uses: zaproxy/action-baseline@v0.3.0
+      with:
+        target: 'http://localhost:9080'
     
     - name: Make the cloudgov-deploy script executable
-      if: success() 
+      if: ${{ success() }}
       run: chmod +x ./bin/deploy-cloudgov
     
     - name: Deploy the app to cloud.gov
-      if: success()
+      if: ${{ success() }}
       run: ./bin/deploy-cloudgov

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
     - name: ZAP Scan
       uses: zaproxy/action-baseline@v0.3.0
       with:
-        target: 'http://172.17.0.1:9080'
+        target: 'http://172.17.0.1'
     
     - name: Make the cloudgov-deploy script executable
       if: ${{ success() }}


### PR DESCRIPTION
### The addition of an OWASP ZAP baseline scan to the github actions workflow:

 "The ZAP baseline action scans a target URL for vulnerabilities and maintains an issue in GitHub repository for the identified alerts." This baseline scan is a passive scan and does not 'attack' the website. Thus it runs faster and is intended for CI/CD purposes. As it stands, it runs the passive scan, creates an "artifact" detailing the issues and suggestions for improvement, and then creates an Issue in github with these results.

I think we could add a "full scan" that does 'attack' on a cron job or manually using the ZAP web client. There is also an "api scan" that I think would be useful to point at the api and uses OpenAPI / Swagger, which would plug in nicely. 

See [this](https://www.zaproxy.org/docs/docker/) link for more info on the various ZAP docker images we could spin up to do this. Also, see [this](https://github.com/marketplace/actions/owasp-zap-baseline-scan) for info on how I created the action. 

Currently, this scan runs on the app after it is deployed to cloud.gov. After initial investigation, it appears we cannot spin up the app within docker in the action, then spin up the zap container to communicate with it. I'll test out a way this can be done in the future. Currently, the actions must run sequentially and the current app is spun up with --rm to remove the container once it has finished it's tests, which make sense, but would inhibit further communication with it. 