### PR TITLE
Removed Build and deploy badge for deleted go-pull.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # revAMPD
 
-![Build and test](https://github.com/USEPA/revampd/workflows/Build%20and%20test/badge.svg)
-
 ![Build, test, deploy](https://github.com/USEPA/revampd/workflows/Build,%20test,%20deploy/badge.svg)
 
 


### PR DESCRIPTION
Removing Build and deploy badge as it is not needed for the streamlined go.yml workflow. 