### PR TITLE
Updated the cloud.gov space name

### DIFF
--- a/bin/deploy-cloudgov
+++ b/bin/deploy-cloudgov
@@ -4,7 +4,7 @@ set -e
 
 CF_LOGIN="https://api.fr.cloud.gov"
 CF_ORG="epa-prototyping"
-CF_SPACE="dev-ampd"
+CF_SPACE="revampd"
 API_NAME="revampd-api"
 API_MANIFEST="etc/manifests/api.yml"
 FRONTEND_NAME="revampd"

--- a/bin/setup-cloudgov
+++ b/bin/setup-cloudgov
@@ -5,7 +5,7 @@
 set -e
 
 CF_ORG="epa-prototyping"
-CF_SPACE="dev-ampd"
+CF_SPACE="revampd"
 DB_NAME="revampd-psql" # bound to app in etc/manifests/api.yml
 
 cf target -o $CF_ORG -s $CF_SPACE


### PR DESCRIPTION
This fixes issue #56.  The cloud.gov space name was changed without updating the deployment scripts.