### PR TITLE
Fix SSI in Cloud.gov

### DIFF
--- a/etc/manifests/frontend.yml
+++ b/etc/manifests/frontend.yml
@@ -4,4 +4,3 @@ applications:
   memory: 64M
   domain: app.cloud.gov
   buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
-  ssi: enabled

--- a/html/Staticfile
+++ b/html/Staticfile
@@ -1,0 +1,1 @@
+ssi: enabled


### PR DESCRIPTION
This fixes issue #59.  I added a "Staticfile" in the html directory which enables server side includes (SSI) for the frontend web server.  The SSI directives are in the index.html for both the data table page and the swagger-ui.  Previously this config was in the frontend manifest and it was not read by cloud foundry when the app was deployed.